### PR TITLE
Removed references to nonexistent fields in get_current_user and referenced schema membership in change_password

### DIFF
--- a/build/dist/pg_auth.sql
+++ b/build/dist/pg_auth.sql
@@ -1,4 +1,4 @@
--- built on Wed Mar 18 2015 08:56:15 GMT+0100 (CET)
+-- built on Mon Jul 27 2015 20:24:30 GMT-0500 (CDT)
 
 BEGIN;
 
@@ -461,10 +461,7 @@ returns TABLE(
     member_id bigint,
     email varchar(255),
     first varchar(50),
-    last varchar(50),
-    last_signin_at timestamptz,
-    profile json,
-    status varchar(20))
+    last varchar(50))
 as
 $$
 DECLARE
@@ -487,13 +484,11 @@ begin
     select found_user.id,
     found_user.email,
     found_user.first,
-    found_user.last,
-    found_user.last_signin_at,
-    found_user.profile,
-    found_user.status;
+    found_user.last;
 
 end;
 $$ language plpgsql;
+
 
 create or replace function get_member(member_id bigint)
 returns setof member_summary

--- a/build/dist/pg_auth.sql
+++ b/build/dist/pg_auth.sql
@@ -1,4 +1,4 @@
--- built on Mon Jul 27 2015 20:24:30 GMT-0500 (CDT)
+-- built on Mon Jul 27 2015 20:28:40 GMT-0500 (CDT)
 
 BEGIN;
 
@@ -432,13 +432,13 @@ BEGIN
   --first, verify that the old password is correct and also find the user
   select membership.logins.member_id from membership.logins
   where membership.logins.provider_key=member_email
-  AND membership.logins.provider_token = crypt(old_password,provider_token)
+  AND membership.logins.provider_token = membership.crypt(old_password,provider_token)
   AND membership.logins.provider='local' into found_id;
 
 
   if found_id IS NOT NULL THEN
     -- crypt the new one and save it
-    update membership.logins set provider_token = crypt(new_password, gen_salt('bf', 10))
+    update membership.logins set provider_token = membership.crypt(new_password, membership.gen_salt('bf', 10))
     where member_id = found_id AND provider='local';
 
     -- log the change
@@ -455,6 +455,7 @@ BEGIN
   select return_message,password_changed;
 END;
 $$ LANGUAGE PLPGSQL;
+
 
 create or replace function get_current_user(session_id bigint)
 returns TABLE(

--- a/build/src/functions/change_password.sql
+++ b/build/src/functions/change_password.sql
@@ -19,13 +19,13 @@ BEGIN
   --first, verify that the old password is correct and also find the user
   select membership.logins.member_id from membership.logins
   where membership.logins.provider_key=member_email
-  AND membership.logins.provider_token = crypt(old_password,provider_token)
+  AND membership.logins.provider_token = membership.crypt(old_password,provider_token)
   AND membership.logins.provider='local' into found_id;
 
 
   if found_id IS NOT NULL THEN
     -- crypt the new one and save it
-    update membership.logins set provider_token = crypt(new_password, gen_salt('bf', 10))
+    update membership.logins set provider_token = membership.crypt(new_password, membership.gen_salt('bf', 10))
     where member_id = found_id AND provider='local';
 
     -- log the change

--- a/build/src/functions/get_current_user.sql
+++ b/build/src/functions/get_current_user.sql
@@ -3,10 +3,7 @@ returns TABLE(
     member_id bigint,
     email varchar(255),
     first varchar(50),
-    last varchar(50),
-    last_signin_at timestamptz,
-    profile json,
-    status varchar(20))
+    last varchar(50))
 as
 $$
 DECLARE
@@ -29,10 +26,7 @@ begin
     select found_user.id,
     found_user.email,
     found_user.first,
-    found_user.last,
-    found_user.last_signin_at,
-    found_user.profile,
-    found_user.status;
+    found_user.last;
 
 end;
 $$ language plpgsql;


### PR DESCRIPTION
**get_current_user**
Removed references to last_signin_at, profile, and status in get_current_user. These fields don't exist on the members table. I suspect these were leftover from an older version of pg_auth that was used in a pluralsight course.

**change_password**
Noticed in the change_password function there were some references to crypt and gen_salt. However, the install script installs pgcrypt into the membership schema. I updated these function references to use the membership schema.
